### PR TITLE
history

### DIFF
--- a/definition.mqh
+++ b/definition.mqh
@@ -32,9 +32,14 @@ enum AccountType{
 
 enum HistoryInterval{
    Monthly,
-   Yearly
+   Yearly,
+   All
 };
 
+enum EnumLosingStreak{
+   Max, 
+   Last,
+};
 // ------------------------------- TEMPLATES ------------------------------- //
 
 struct RiskProfile{
@@ -92,6 +97,14 @@ struct TradesHistory{
 };
 
 struct PortfolioSeries{
+   double      current_drawdown_percent; 
+   int         max_consecutive_losses;
+   int         last_consecutive_losses;
+   bool        is_losing_streak; 
+   double      max_drawdown_percent; 
+   bool        in_drawdown; 
+   double      peak_equity;
+
    TradesHistory trade_history[];
 } PORTFOLIO;
 
@@ -293,6 +306,8 @@ input PositionSizing    InpSizing         = Dynamic; // POSITION SIZING - Positi
 input float             InpDDScale        = 0.5; // DRAWDOWN SCALING
 input float             InpAbsDDThresh    = 10; // ABSOLUTE DRAWDOWN THRESHOLD
 input HistoryInterval   InpHistInterval   = Yearly; // HISTORY INTERVAL - Tracking Equity Drawdown
+input int               InpMinLoseStreak  = 3; // MINIMUM CONSECUTIVE LOSING TRADES
+input double            InpEquityDDThresh = 5; // EQUITY DRAWDOWN THRESHOLD
 
 input string            InpFunded         = "========== FUNDED =========="; // ========== FUNDED ==========
 input float             InpProfitTarget   = 10; // PROFIT TARGET 

--- a/lambda-zero-one.mq4
+++ b/lambda-zero-one.mq4
@@ -12,3 +12,4 @@
 #property description app_description1
 #property strict 
 
+ 

--- a/script.mqh
+++ b/script.mqh
@@ -18,6 +18,7 @@ int OnInit()
    #ifdef __MQL5__
    Trade.SetExpertMagicNumber(InpMagic);
    #endif 
+   interval_trade.InitHistory();
    interval_trade.SetRiskProfile();
    interval_trade.SetFundedProfile();
    //set_deadline();
@@ -27,7 +28,7 @@ int OnInit()
    interval_app.InitializeUIElements();
    // DRAW UI HERE
    
-   
+   //interval_trade.InitHistory();
    // add provision to check for open orders, in case ea gets deactivated
    //Print("interval_trade.risk_amount: ", interval_trade.risk_amount);
 //---
@@ -62,12 +63,12 @@ void OnTick()
       }
       else{
          if (interval_trade.EquityReachedProfitTarget() && InpAccountType != Personal) {
+            interval_trade.logger("Order Close By Profit Target");
             interval_trade.CloseOrder();
-            Print("CLOSE BY PROFIT TARGET");
          }
          if ((TimeCurrent() >= TRADE_QUEUE.curr_trade_close) && (InpTradeMgt != Trailing && InpTradeMgt != OpenTrailing)) {
-            interval_trade.CloseOrder();         
-            Print("CLOSE BY DEADLINE");
+            interval_trade.logger("Order Close by Deadline");
+            interval_trade.CloseOrder();      
          }
       }
       // check order here. if order is active, increment
@@ -78,9 +79,19 @@ void OnTick()
          interval_trade.logger(StringFormat("Checked Order Pool. %i Positions Found.", positions_added));
          interval_trade.logger(StringFormat("%i Orders in Active List", interval_trade.NumActivePositions()));
       }
-      if (interval_trade.IsNewDay()) { interval_trade.ClearOrdersToday(); }
+      if (interval_trade.IsNewDay()) { 
+         interval_trade.ClearOrdersToday();
+         
+      }
+         
       interval_trade.ModifyOrder();
       interval_app.InitializeUIElements();
+      if (TimeMinute(TimeCurrent()) == 0 && TimeHour(TimeCurrent()) == 15){
+         //interval_trade.ClearHistory();
+         //interval_trade.InitHistory();
+         //interval_trade.AppendToHistory();
+         interval_trade.UpdateHistoryWithLastValue();
+      }
    }
    
   }


### PR DESCRIPTION
added provisions for scanning account history. used for calculating equity drawdown, and adjusting lots. 

mt4 posprofit now takes into account commission. (does not include commission previously)