### PR TITLE
optimization

### DIFF
--- a/definition.mqh
+++ b/definition.mqh
@@ -102,7 +102,7 @@ struct PortfolioSeries{
    // Portfolio Analytics
    bool        in_drawdown, is_losing_streak; 
    double      current_drawdown_percent, max_drawdown_percent, peak_equity; 
-   int         max_consecutive_losses, last_consecutive_losses;
+   int         max_consecutive_losses, last_consecutive_losses, data_points;
 
    TradesHistory trade_history[];
 } PORTFOLIO;
@@ -299,12 +299,12 @@ input float             InpRiskAmount     = 1000; // BASE RISK AMOUNT - Scales l
 input float             InpAllocation     = 1; // ALLOCATION - Percentage of Total Risk
 input TradeManagement   InpTradeMgt       = None; // TRADE MANAGEMENT - BE / Trail Stop
 input float             InpTrailInterval  = 50; // TRAIL STOP INTERVAL - Trail Points Increment
-input float             InpMinimumEquity  = 1000; // MINIMUM EQUITY - Minimum required equity to enable trading.
+input double            InpCutoff         = 0.85; // EQUITY CUTOFF - Once equity breaches cutoff, trading is disabled.
 input float             InpMaxLot         = 1; // MAX LOT - Maximum Allowable Lot 
 input PositionSizing    InpSizing         = Dynamic; // POSITION SIZING - Position Sizing
 input float             InpDDScale        = 0.5; // DRAWDOWN SCALING
 input float             InpAbsDDThresh    = 10; // ABSOLUTE DRAWDOWN THRESHOLD
-input HistoryInterval   InpHistInterval   = Yearly; // HISTORY INTERVAL - Tracking Equity Drawdown
+input HistoryInterval   InpHistInterval   = All; // HISTORY INTERVAL - Tracking Equity Drawdown
 input int               InpMinLoseStreak  = 3; // MINIMUM CONSECUTIVE LOSING TRADES
 input double            InpEquityDDThresh = 5; // EQUITY DRAWDOWN THRESHOLD
 
@@ -315,7 +315,7 @@ input float             InpChallDDScale   = 1; // CHALLENGE ACCOUNT DRAWDOWN SCA
 input float             InpLiveScale      = 0.5; // LIVE ACCOUNT SCALING
 input float             InpLiveDDScale    = 0.25; // LIVE ACCOUNT DRAWDOWN SCALING
 input float             InpMinTargetPts   = 50; // MIN TP POINTS
-input float             InpPropDDThresh  = 5; // CHALLENGE ACCOUNT DRAWDOWN THRESHOLD 
+input float             InpPropDDThresh   = 5; // CHALLENGE ACCOUNT DRAWDOWN THRESHOLD 
 
 input string            InpMisc           = "========== MISC =========="; // ========== MISC ==========
 input SpreadManagement  InpSpreadMgt      = Recursive; // SPREAD MANAGEMENT

--- a/script.mqh
+++ b/script.mqh
@@ -18,16 +18,18 @@ int OnInit()
    #ifdef __MQL5__
    Trade.SetExpertMagicNumber(InpMagic);
    #endif 
+   interval_trade.InitializeSymbolProperties();
    interval_trade.InitHistory();
    interval_trade.SetRiskProfile();
    interval_trade.SetFundedProfile();
    //set_deadline();
    
+   interval_app.RefreshClass(interval_trade);
    interval_trade.OrdersEA();
    interval_trade.SetNextTradeWindow();
    interval_app.InitializeUIElements();
    // DRAW UI HERE
-   
+   PrintFormat("Symbol Properties | Tick Value: %f, Trade Points: %f", interval_trade.tick_value, interval_trade.trade_points);
    //interval_trade.InitHistory();
    // add provision to check for open orders, in case ea gets deactivated
    //Print("interval_trade.risk_amount: ", interval_trade.risk_amount);
@@ -41,8 +43,11 @@ int OnInit()
 void OnDeinit(const int reason)
   {
 //---
+   //PrintFormat("REASON: %i", reason);
    Print("Test Finished");
-   PrintFormat("In Drawdown: %i, DD Percent: %f, Max DD Percent: %f, Losing Streak: %i, Last Consecutive: %i, Max Consecutive: %i, Peak: %f, Current: %f", 
+   //Print(__FUNCTION__);
+   PrintFormat("Datapoints: %i, In Drawdown: %i, DD Percent: %f, Max DD Percent: %f, Losing Streak: %i, Last Consecutive: %i, Max Consecutive: %i, Peak: %f, Current: %f", 
+      interval_trade.PortfolioHistorySize(),
       PORTFOLIO.in_drawdown, 
       PORTFOLIO.current_drawdown_percent, 
       PORTFOLIO.max_drawdown_percent,
@@ -51,28 +56,25 @@ void OnDeinit(const int reason)
       PORTFOLIO.max_consecutive_losses,
       PORTFOLIO.peak_equity, 
       interval_trade.account_balance());
+   
    ObjectsDeleteAll(0, 0, -1);
+   
+
   }
   
   
 void OnTick()
   {
    if (IsNewCandle() && interval_trade.CorrectPeriod() && interval_trade.MinimumEquity()){
-      // CONDITION 1: New interval, Correct Timeframe, Minimum Equity Requirements.
-      // check here for time interval 
       if (interval_trade.ValidTradeOpen()){
-         // time is in between open and close time 
          if (interval_trade.SendMarketOrder() == -1) { 
-            // add recusrion here? 
-            // store last open price, and use it as reference, for delayed entry
-            //interval_trade.set_delayed_entry(last_candle_open());
             
          }
-            //send_limit_order();
 
       }
       else{
          if (interval_trade.EquityReachedProfitTarget() && InpAccountType != Personal) {
+         
             interval_trade.logger("Order Close By Profit Target");
             interval_trade.CloseOrder();
          }
@@ -95,12 +97,9 @@ void OnTick()
       }
          
       interval_trade.ModifyOrder();
-      interval_app.InitializeUIElements();
+      //interval_app.InitializeUIElements();
       if (TimeMinute(TimeCurrent()) == 0 && TimeHour(TimeCurrent()) == 15){
-         //interval_trade.ClearHistory();
-         //interval_trade.InitHistory();
-         //interval_trade.AppendToHistory();
-         interval_trade.UpdateHistoryWithLastValue();
+         //interval_trade.UpdateHistoryWithLastValue();
       }
    }
    
@@ -115,3 +114,5 @@ void OnChartEvent(const int id, const long &lparam, const double &daram, const s
    }
 }
 //+------------------------------------------------------------------+
+
+


### PR DESCRIPTION
app
- added refresh class
- added switch to update values 

definition
- changed minimum equity to percentage cutoff 
- changed history default to all instead of years 

script
- disabled refreshing ui elements on main loop (algo runs very slow if ui updated during main loop) 

trade 
- added functions for calculating value at risk 
- added additional functions for history (checking tickets, etc) 
- calclot -> added filter when calculated lot exceeds symbol lot size limits 
- added function for getting entry candle open, in case algo fails at trade time. this allows algo to trade when price is valid. entry candle open is taken by ibarshift.
